### PR TITLE
Add periods to user registry section wildcards

### DIFF
--- a/filter_windows.txt
+++ b/filter_windows.txt
@@ -227,11 +227,11 @@
 ###############
 # Users Registry hives & associated logs
 ###############
-/Documents and Settings/*/ntuser[.]dat
-/Users/*/AppData/Local/Microsoft/Windows/UsrClass[.]dat
-/Users/*/AppData/Local/Microsoft/Windows/UsrClass[.]dat[.]LOG[1-9]
-/Users/*/ntuser[.]dat
-/Users/*/ntuser[.]dat[.]LOG[1-9]
+/Documents and Settings/.*/ntuser[.]dat
+/Users/.*/AppData/Local/Microsoft/Windows/UsrClass[.]dat
+/Users/.*/AppData/Local/Microsoft/Windows/UsrClass[.]dat[.]LOG[1-9]
+/Users/.*/ntuser[.]dat
+/Users/.*/ntuser[.]dat[.]LOG[1-9]
 
 ###############
 # Recent file activity


### PR DESCRIPTION
Hi, 

Thanks for sharing these plaso filters! I noticed that when I was using the filter_windows.txt list with log2timeline, user registry hives weren't being pulled in. I'm pretty new to this toolset but I assumed it's because it's parsing the filters as regexes... adding periods before each of the *s seemed to fix the issue for me, but perhaps I was just doing something else wrong.

cheers,Ben